### PR TITLE
Make hints more readable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ bun.lockb
 
 vitesse/
 output/
+
+vitesse

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,294 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.14.15
+      glob:
+        specifier: ^10.3.10
+        version: 10.4.5
+
+packages:
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@types/node@20.14.15':
+    resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  foreground-child@3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+    engines: {node: '>=14'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  package-json-from-dist@1.0.0:
+    resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@types/node@20.14.15':
+    dependencies:
+      undici-types: 5.26.5
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.0.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  foreground-child@3.3.0:
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.1.0
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.0
+      path-scurry: 1.11.1
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  lru-cache@10.4.3: {}
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minipass@7.1.2: {}
+
+  package-json-from-dist@1.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.0.1
+
+  undici-types@5.26.5: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0

--- a/run.js
+++ b/run.js
@@ -4,20 +4,29 @@ const filepath = require('path')
 const { glob } = require('glob')
 const vitesseRepo = 'vitesse'
 
+const THEME_IMPORTER = process.env.THEME_IMPORTER ?? '/Users/d1y/github/zed/target/debug'
+
 async function main() {
   if (!fs.existsSync(vitesseRepo)) {
     const repo = 'https://github.com/antfu/vscode-theme-vitesse'
-    console.log(`git clone ${repo}`)
-    execSync(`git clone  ${vitesseRepo}`)
+    const cmd = `git clone ${repo} ${vitesseRepo} --depth=1`
+    console.log(cmd)
+    execSync(cmd)
   }
+
   /**
    * @type {Array<string>}
    */
   const jsonFiles = await glob(`${vitesseRepo}/themes/*.json`)
+  if (!fs.existsSync('output')) {
+    fs.mkdirSync('output')
+  }
+
   jsonFiles.forEach((json) => {
     const file = filepath.basename(json)
-    themeImporter(json, `output/${file}`)
+    transformTheme(json, `output/${file}`)
   })
+
   const result = {
     $schema: 'https://zed.dev/schema/themes/v0.1.0.json',
     name: 'Vitesse',
@@ -42,12 +51,98 @@ async function main() {
   fs.writeFileSync(outputFile, data)
 }
 
-function themeImporter(input, output) {
-  execSync(`theme_importer ${input} -o ${output}`, {
-    env: {
-      PATH: '/Users/d1y/github/zed/target/debug', // TODO: add `theme_importer` env
-    },
+function transformTheme(input, output) {
+  const result = execSync(`theme_importer ${input}`, {
+    encoding: 'utf8',
+    env: { PATH: THEME_IMPORTER, },
   })
+  const themeJson = JSON.parse(result)
+
+  // these props are null by default which will cause the hint tips hard to read
+  const patchedProperties = [
+    "conflict.background",
+    "conflict.border",
+    "created.background",
+    "created.border",
+    "deleted.background",
+    "deleted.border",
+    "error.background",
+    "error.border",
+    "hidden.background",
+    "hidden.border",
+    "hint.background",
+    "hint.border",
+    "ignored.background",
+    "ignored.border",
+    "info.background",
+    "info.border",
+    "modified.background",
+    "modified.border",
+    "predictive.background",
+    "predictive.border",
+    "renamed.background",
+    "renamed.border",
+    "success.background",
+    "success.border",
+    "unreachable.background",
+    "unreachable.border",
+    "warning.background",
+    "warning.border",
+  ]
+
+  const style = themeJson.style
+  for (const prop of patchedProperties) {
+    const mappedKey = prop.split('.')[0]
+    // use correct values to override nulls
+    style[prop] = style[mappedKey]
+  }
+
+  // use andromeda's config directly
+  // https://github.com/zed-industries/zed/blob/355aebd0e493aa9f60900179acf8011a1fc9117b/assets/themes/andromeda/andromeda.json#L139
+  style.players = [
+    {
+      "cursor": "#10a793ff",
+      "background": "#10a793ff",
+      "selection": "#10a7933d"
+    },
+    {
+      "cursor": "#c74cecff",
+      "background": "#c74cecff",
+      "selection": "#c74cec3d"
+    },
+    {
+      "cursor": "#f29c14ff",
+      "background": "#f29c14ff",
+      "selection": "#f29c143d"
+    },
+    {
+      "cursor": "#893ea6ff",
+      "background": "#893ea6ff",
+      "selection": "#893ea63d"
+    },
+    {
+      "cursor": "#08e7c5ff",
+      "background": "#08e7c5ff",
+      "selection": "#08e7c53d"
+    },
+    {
+      "cursor": "#f82871ff",
+      "background": "#f82871ff",
+      "selection": "#f828713d"
+    },
+    {
+      "cursor": "#fee56cff",
+      "background": "#fee56cff",
+      "selection": "#fee56c3d"
+    },
+    {
+      "cursor": "#96df71ff",
+      "background": "#96df71ff",
+      "selection": "#96df713d"
+    }
+  ]
+
+  fs.writeFileSync(output, JSON.stringify(themeJson, null, 2))
 }
 
 main()

--- a/themes/vitesse.json
+++ b/themes/vitesse.json
@@ -7,6 +7,8 @@
       "name": "Vitesse Light",
       "appearance": "light",
       "style": {
+        "background.appearance": "opaque",
+        "accents": [],
         "border": "#f0f0f0",
         "border.variant": "#f0f0f0",
         "border.focused": "#00000000",
@@ -39,6 +41,7 @@
         "icon.accent": null,
         "status_bar.background": "#ffffff",
         "title_bar.background": "#ffffff",
+        "title_bar.inactive_background": null,
         "toolbar.background": "#f7f7f7",
         "tab_bar.background": "#ffffff",
         "tab.inactive_background": "#ffffff",
@@ -47,6 +50,7 @@
         "panel.background": "#ffffff",
         "panel.focused_border": null,
         "pane.focused_border": null,
+        "pane_group.border": "#f0f0f0",
         "scrollbar.thumb.background": "#393a3410",
         "scrollbar.thumb.hover_background": "#393a3450",
         "scrollbar.thumb.border": "#393a3410",
@@ -63,6 +67,8 @@
         "editor.invisible": null,
         "editor.wrap_guide": "#f0f0f0",
         "editor.active_wrap_guide": "#f0f0f0",
+        "editor.indent_guide": null,
+        "editor.indent_guide_active": null,
         "editor.document_highlight.read_background": null,
         "editor.document_highlight.write_background": null,
         "terminal.background": null,
@@ -95,32 +101,32 @@
         "terminal.ansi.dim_white": null,
         "link_text.hover": "#1c6b48",
         "conflict": "#a65e2b",
-        "conflict.background": null,
-        "conflict.border": null,
+        "conflict.background": "#a65e2b",
+        "conflict.border": "#a65e2b",
         "created": "#1e754f",
-        "created.background": null,
-        "created.border": null,
+        "created.background": "#1e754f",
+        "created.border": "#1e754f",
         "deleted": "#ab5959",
-        "deleted.background": null,
-        "deleted.border": null,
+        "deleted.background": "#ab5959",
+        "deleted.border": "#ab5959",
         "error": "#ab5959",
-        "error.background": null,
-        "error.border": null,
+        "error.background": "#ab5959",
+        "error.border": "#ab5959",
         "hidden": "#6a737d",
-        "hidden.background": null,
-        "hidden.border": null,
+        "hidden.background": "#6a737d",
+        "hidden.border": "#6a737d",
         "hint": "#999999",
-        "hint.background": null,
-        "hint.border": null,
+        "hint.background": "#999999",
+        "hint.border": "#999999",
         "ignored": "#393a3450",
-        "ignored.background": null,
-        "ignored.border": null,
+        "ignored.background": "#393a3450",
+        "ignored.border": "#393a3450",
         "info": "#296aa3",
-        "info.background": null,
-        "info.border": null,
+        "info.background": "#296aa3",
+        "info.border": "#296aa3",
         "modified": "#296aa3",
-        "modified.background": null,
-        "modified.border": null,
+        "modified.background": "#296aa3",
+        "modified.border": "#296aa3",
         "predictive": null,
         "predictive.background": null,
         "predictive.border": null,
@@ -134,748 +140,234 @@
         "unreachable.background": null,
         "unreachable.border": null,
         "warning": "#a65e2b",
-        "warning.background": null,
-        "warning.border": null,
-        "players": [],
+        "warning.background": "#a65e2b",
+        "warning.border": "#a65e2b",
+        "players": [
+          {
+            "cursor": "#10a793ff",
+            "background": "#10a793ff",
+            "selection": "#10a7933d"
+          },
+          {
+            "cursor": "#c74cecff",
+            "background": "#c74cecff",
+            "selection": "#c74cec3d"
+          },
+          {
+            "cursor": "#f29c14ff",
+            "background": "#f29c14ff",
+            "selection": "#f29c143d"
+          },
+          {
+            "cursor": "#893ea6ff",
+            "background": "#893ea6ff",
+            "selection": "#893ea63d"
+          },
+          {
+            "cursor": "#08e7c5ff",
+            "background": "#08e7c5ff",
+            "selection": "#08e7c53d"
+          },
+          {
+            "cursor": "#f82871ff",
+            "background": "#f82871ff",
+            "selection": "#f828713d"
+          },
+          {
+            "cursor": "#fee56cff",
+            "background": "#fee56cff",
+            "selection": "#fee56c3d"
+          },
+          {
+            "cursor": "#96df71ff",
+            "background": "#96df71ff",
+            "selection": "#96df713d"
+          }
+        ],
         "syntax": {
           "attribute": {
             "color": "#b07d48",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "comment": {
             "color": "#a0ada0",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
             "color": "#a0ada0",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "constant": {
             "color": "#a65e2b",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
             "color": "#393a34",
+            "background_color": null,
             "font_style": "italic",
             "font_weight": null
           },
           "emphasis.strong": {
             "color": "#393a34",
+            "background_color": null,
             "font_style": null,
             "font_weight": 700
           },
           "function": {
             "color": "#59873a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "keyword": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "label": {
             "color": "#59873a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "link_uri": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "number": {
             "color": "#2f798a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "operator": {
             "color": "#ab5959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "tag": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "title": {
             "color": "#59873a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "type": {
             "color": "#2e8f82",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "variable": {
             "color": "#b07d48",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "variable.special": {
             "color": "#a65e2b",
-            "font_style": null,
-            "font_weight": null
-          }
-        }
-      }
-    },
-    {
-      "name": "Vitesse Dark Soft",
-      "appearance": "dark",
-      "style": {
-        "border": "#252525",
-        "border.variant": "#252525",
-        "border.focused": "#00000000",
-        "border.selected": "#252525",
-        "border.transparent": "#252525",
-        "border.disabled": "#252525",
-        "elevated_surface.background": "#222",
-        "surface.background": "#222",
-        "background": "#222",
-        "element.background": "#4d9375",
-        "element.hover": "#292929",
-        "element.active": null,
-        "element.selected": "#292929",
-        "element.disabled": null,
-        "drop_target.background": null,
-        "ghost_element.background": null,
-        "ghost_element.hover": "#292929",
-        "ghost_element.active": null,
-        "ghost_element.selected": "#292929",
-        "ghost_element.disabled": null,
-        "text": "#dbd7caee",
-        "text.muted": "#959da5",
-        "text.placeholder": null,
-        "text.disabled": null,
-        "text.accent": null,
-        "icon": null,
-        "icon.muted": null,
-        "icon.disabled": null,
-        "icon.placeholder": null,
-        "icon.accent": null,
-        "status_bar.background": "#222",
-        "title_bar.background": "#222",
-        "toolbar.background": "#292929",
-        "tab_bar.background": "#222",
-        "tab.inactive_background": "#222",
-        "tab.active_background": "#222",
-        "search.match_background": null,
-        "panel.background": "#222",
-        "panel.focused_border": null,
-        "pane.focused_border": null,
-        "scrollbar.thumb.background": "#dedcd510",
-        "scrollbar.thumb.hover_background": "#dedcd550",
-        "scrollbar.thumb.border": "#dedcd510",
-        "scrollbar.track.background": "#222",
-        "scrollbar.track.border": "#111",
-        "editor.foreground": "#dbd7caee",
-        "editor.background": "#222",
-        "editor.gutter.background": "#222",
-        "editor.subheader.background": null,
-        "editor.active_line.background": "#292929",
-        "editor.highlighted_line.background": null,
-        "editor.line_number": "#dedcd550",
-        "editor.active_line_number": "#dbd7caee",
-        "editor.invisible": null,
-        "editor.wrap_guide": "#252525",
-        "editor.active_wrap_guide": "#252525",
-        "editor.document_highlight.read_background": null,
-        "editor.document_highlight.write_background": null,
-        "terminal.background": null,
-        "terminal.foreground": null,
-        "terminal.bright_foreground": null,
-        "terminal.dim_foreground": null,
-        "terminal.ansi.black": "#393a34",
-        "terminal.ansi.bright_black": "#777777",
-        "terminal.ansi.dim_black": null,
-        "terminal.ansi.red": "#cb7676",
-        "terminal.ansi.bright_red": "#cb7676",
-        "terminal.ansi.dim_red": null,
-        "terminal.ansi.green": "#4d9375",
-        "terminal.ansi.bright_green": "#4d9375",
-        "terminal.ansi.dim_green": null,
-        "terminal.ansi.yellow": "#e6cc77",
-        "terminal.ansi.bright_yellow": "#e6cc77",
-        "terminal.ansi.dim_yellow": null,
-        "terminal.ansi.blue": "#6394bf",
-        "terminal.ansi.bright_blue": "#6394bf",
-        "terminal.ansi.dim_blue": null,
-        "terminal.ansi.magenta": "#d9739f",
-        "terminal.ansi.bright_magenta": "#d9739f",
-        "terminal.ansi.dim_magenta": null,
-        "terminal.ansi.cyan": "#5eaab5",
-        "terminal.ansi.bright_cyan": "#5eaab5",
-        "terminal.ansi.dim_cyan": null,
-        "terminal.ansi.white": "#dbd7ca",
-        "terminal.ansi.bright_white": "#ffffff",
-        "terminal.ansi.dim_white": null,
-        "link_text.hover": "#4d9375",
-        "conflict": "#d4976c",
-        "conflict.background": null,
-        "conflict.border": null,
-        "created": "#4d9375",
-        "created.background": null,
-        "created.border": null,
-        "deleted": "#cb7676",
-        "deleted.background": null,
-        "deleted.border": null,
-        "error": "#cb7676",
-        "error.background": null,
-        "error.border": null,
-        "hidden": "#959da5",
-        "hidden.background": null,
-        "hidden.border": null,
-        "hint": "#666666",
-        "hint.background": null,
-        "hint.border": null,
-        "ignored": "#dedcd550",
-        "ignored.background": null,
-        "ignored.border": null,
-        "info": "#6394bf",
-        "info.background": null,
-        "info.border": null,
-        "modified": "#6394bf",
-        "modified.background": null,
-        "modified.border": null,
-        "predictive": null,
-        "predictive.background": null,
-        "predictive.border": null,
-        "renamed": null,
-        "renamed.background": null,
-        "renamed.border": null,
-        "success": null,
-        "success.background": null,
-        "success.border": null,
-        "unreachable": null,
-        "unreachable.background": null,
-        "unreachable.border": null,
-        "warning": "#d4976c",
-        "warning.background": null,
-        "warning.border": null,
-        "players": [],
-        "syntax": {
-          "attribute": {
-            "color": "#bd976a",
-            "font_style": null,
-            "font_weight": null
-          },
-          "boolean": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "comment": {
-            "color": "#758575dd",
-            "font_style": null,
-            "font_weight": null
-          },
-          "comment.doc": {
-            "color": "#758575dd",
-            "font_style": null,
-            "font_weight": null
-          },
-          "constant": {
-            "color": "#c99076",
-            "font_style": null,
-            "font_weight": null
-          },
-          "constructor": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "emphasis": {
-            "color": "#dbd7caee",
-            "font_style": "italic",
-            "font_weight": null
-          },
-          "emphasis.strong": {
-            "color": "#dbd7caee",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "function": {
-            "color": "#80a665",
-            "font_style": null,
-            "font_weight": null
-          },
-          "keyword": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "label": {
-            "color": "#80a665",
-            "font_style": null,
-            "font_weight": null
-          },
-          "link_text": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "link_uri": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "number": {
-            "color": "#4C9A91",
-            "font_style": null,
-            "font_weight": null
-          },
-          "operator": {
-            "color": "#cb7676",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.bracket": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.delimiter": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.list_marker": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.special": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.escape": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.regex": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.special": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.special.symbol": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "tag": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "title": {
-            "color": "#80a665",
-            "font_style": null,
-            "font_weight": null
-          },
-          "type": {
-            "color": "#5DA994",
-            "font_style": null,
-            "font_weight": null
-          },
-          "variable": {
-            "color": "#bd976a",
-            "font_style": null,
-            "font_weight": null
-          },
-          "variable.special": {
-            "color": "#c99076",
-            "font_style": null,
-            "font_weight": null
-          }
-        }
-      }
-    },
-    {
-      "name": "Vitesse Dark",
-      "appearance": "dark",
-      "style": {
-        "border": "#191919",
-        "border.variant": "#191919",
-        "border.focused": "#00000000",
-        "border.selected": "#191919",
-        "border.transparent": "#191919",
-        "border.disabled": "#191919",
-        "elevated_surface.background": "#121212",
-        "surface.background": "#121212",
-        "background": "#121212",
-        "element.background": "#4d9375",
-        "element.hover": "#181818",
-        "element.active": null,
-        "element.selected": "#181818",
-        "element.disabled": null,
-        "drop_target.background": null,
-        "ghost_element.background": null,
-        "ghost_element.hover": "#181818",
-        "ghost_element.active": null,
-        "ghost_element.selected": "#181818",
-        "ghost_element.disabled": null,
-        "text": "#dbd7caee",
-        "text.muted": "#959da5",
-        "text.placeholder": null,
-        "text.disabled": null,
-        "text.accent": null,
-        "icon": null,
-        "icon.muted": null,
-        "icon.disabled": null,
-        "icon.placeholder": null,
-        "icon.accent": null,
-        "status_bar.background": "#121212",
-        "title_bar.background": "#121212",
-        "toolbar.background": "#181818",
-        "tab_bar.background": "#121212",
-        "tab.inactive_background": "#121212",
-        "tab.active_background": "#121212",
-        "search.match_background": null,
-        "panel.background": "#121212",
-        "panel.focused_border": null,
-        "pane.focused_border": null,
-        "scrollbar.thumb.background": "#dedcd510",
-        "scrollbar.thumb.hover_background": "#dedcd550",
-        "scrollbar.thumb.border": "#dedcd510",
-        "scrollbar.track.background": "#121212",
-        "scrollbar.track.border": "#111",
-        "editor.foreground": "#dbd7caee",
-        "editor.background": "#121212",
-        "editor.gutter.background": "#121212",
-        "editor.subheader.background": null,
-        "editor.active_line.background": "#181818",
-        "editor.highlighted_line.background": null,
-        "editor.line_number": "#dedcd550",
-        "editor.active_line_number": "#dbd7caee",
-        "editor.invisible": null,
-        "editor.wrap_guide": "#191919",
-        "editor.active_wrap_guide": "#191919",
-        "editor.document_highlight.read_background": null,
-        "editor.document_highlight.write_background": null,
-        "terminal.background": null,
-        "terminal.foreground": null,
-        "terminal.bright_foreground": null,
-        "terminal.dim_foreground": null,
-        "terminal.ansi.black": "#393a34",
-        "terminal.ansi.bright_black": "#777777",
-        "terminal.ansi.dim_black": null,
-        "terminal.ansi.red": "#cb7676",
-        "terminal.ansi.bright_red": "#cb7676",
-        "terminal.ansi.dim_red": null,
-        "terminal.ansi.green": "#4d9375",
-        "terminal.ansi.bright_green": "#4d9375",
-        "terminal.ansi.dim_green": null,
-        "terminal.ansi.yellow": "#e6cc77",
-        "terminal.ansi.bright_yellow": "#e6cc77",
-        "terminal.ansi.dim_yellow": null,
-        "terminal.ansi.blue": "#6394bf",
-        "terminal.ansi.bright_blue": "#6394bf",
-        "terminal.ansi.dim_blue": null,
-        "terminal.ansi.magenta": "#d9739f",
-        "terminal.ansi.bright_magenta": "#d9739f",
-        "terminal.ansi.dim_magenta": null,
-        "terminal.ansi.cyan": "#5eaab5",
-        "terminal.ansi.bright_cyan": "#5eaab5",
-        "terminal.ansi.dim_cyan": null,
-        "terminal.ansi.white": "#dbd7ca",
-        "terminal.ansi.bright_white": "#ffffff",
-        "terminal.ansi.dim_white": null,
-        "link_text.hover": "#4d9375",
-        "conflict": "#d4976c",
-        "conflict.background": null,
-        "conflict.border": null,
-        "created": "#4d9375",
-        "created.background": null,
-        "created.border": null,
-        "deleted": "#cb7676",
-        "deleted.background": null,
-        "deleted.border": null,
-        "error": "#cb7676",
-        "error.background": null,
-        "error.border": null,
-        "hidden": "#959da5",
-        "hidden.background": null,
-        "hidden.border": null,
-        "hint": "#666666",
-        "hint.background": null,
-        "hint.border": null,
-        "ignored": "#dedcd550",
-        "ignored.background": null,
-        "ignored.border": null,
-        "info": "#6394bf",
-        "info.background": null,
-        "info.border": null,
-        "modified": "#6394bf",
-        "modified.background": null,
-        "modified.border": null,
-        "predictive": null,
-        "predictive.background": null,
-        "predictive.border": null,
-        "renamed": null,
-        "renamed.background": null,
-        "renamed.border": null,
-        "success": null,
-        "success.background": null,
-        "success.border": null,
-        "unreachable": null,
-        "unreachable.background": null,
-        "unreachable.border": null,
-        "warning": "#d4976c",
-        "warning.background": null,
-        "warning.border": null,
-        "players": [],
-        "syntax": {
-          "attribute": {
-            "color": "#bd976a",
-            "font_style": null,
-            "font_weight": null
-          },
-          "boolean": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "comment": {
-            "color": "#758575dd",
-            "font_style": null,
-            "font_weight": null
-          },
-          "comment.doc": {
-            "color": "#758575dd",
-            "font_style": null,
-            "font_weight": null
-          },
-          "constant": {
-            "color": "#c99076",
-            "font_style": null,
-            "font_weight": null
-          },
-          "constructor": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "emphasis": {
-            "color": "#dbd7caee",
-            "font_style": "italic",
-            "font_weight": null
-          },
-          "emphasis.strong": {
-            "color": "#dbd7caee",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "function": {
-            "color": "#80a665",
-            "font_style": null,
-            "font_weight": null
-          },
-          "keyword": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "label": {
-            "color": "#80a665",
-            "font_style": null,
-            "font_weight": null
-          },
-          "link_text": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "link_uri": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "number": {
-            "color": "#4C9A91",
-            "font_style": null,
-            "font_weight": null
-          },
-          "operator": {
-            "color": "#cb7676",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.bracket": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.delimiter": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.list_marker": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "punctuation.special": {
-            "color": "#666666",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.escape": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.regex": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.special": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "string.special.symbol": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "tag": {
-            "color": "#4d9375",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#c98a7d",
-            "font_style": null,
-            "font_weight": null
-          },
-          "title": {
-            "color": "#80a665",
-            "font_style": null,
-            "font_weight": null
-          },
-          "type": {
-            "color": "#5DA994",
-            "font_style": null,
-            "font_weight": null
-          },
-          "variable": {
-            "color": "#bd976a",
-            "font_style": null,
-            "font_weight": null
-          },
-          "variable.special": {
-            "color": "#c99076",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           }
@@ -886,6 +378,8 @@
       "name": "Vitesse Light Soft",
       "appearance": "light",
       "style": {
+        "background.appearance": "opaque",
+        "accents": [],
         "border": "#E7E5DB",
         "border.variant": "#E7E5DB",
         "border.focused": "#00000000",
@@ -918,6 +412,7 @@
         "icon.accent": null,
         "status_bar.background": "#F1F0E9",
         "title_bar.background": "#F1F0E9",
+        "title_bar.inactive_background": null,
         "toolbar.background": "#E7E5DB",
         "tab_bar.background": "#F1F0E9",
         "tab.inactive_background": "#F1F0E9",
@@ -926,6 +421,7 @@
         "panel.background": "#F1F0E9",
         "panel.focused_border": null,
         "pane.focused_border": null,
+        "pane_group.border": "#E7E5DB",
         "scrollbar.thumb.background": "#393a3410",
         "scrollbar.thumb.hover_background": "#393a3450",
         "scrollbar.thumb.border": "#393a3410",
@@ -942,6 +438,8 @@
         "editor.invisible": null,
         "editor.wrap_guide": "#E7E5DB",
         "editor.active_wrap_guide": "#E7E5DB",
+        "editor.indent_guide": null,
+        "editor.indent_guide_active": null,
         "editor.document_highlight.read_background": null,
         "editor.document_highlight.write_background": null,
         "terminal.background": null,
@@ -974,32 +472,32 @@
         "terminal.ansi.dim_white": null,
         "link_text.hover": "#1c6b48",
         "conflict": "#a65e2b",
-        "conflict.background": null,
-        "conflict.border": null,
+        "conflict.background": "#a65e2b",
+        "conflict.border": "#a65e2b",
         "created": "#1e754f",
-        "created.background": null,
-        "created.border": null,
+        "created.background": "#1e754f",
+        "created.border": "#1e754f",
         "deleted": "#ab5959",
-        "deleted.background": null,
-        "deleted.border": null,
+        "deleted.background": "#ab5959",
+        "deleted.border": "#ab5959",
         "error": "#ab5959",
-        "error.background": null,
-        "error.border": null,
+        "error.background": "#ab5959",
+        "error.border": "#ab5959",
         "hidden": "#6a737d",
-        "hidden.background": null,
-        "hidden.border": null,
+        "hidden.background": "#6a737d",
+        "hidden.border": "#6a737d",
         "hint": "#999999",
-        "hint.background": null,
-        "hint.border": null,
+        "hint.background": "#999999",
+        "hint.border": "#999999",
         "ignored": "#393a3450",
-        "ignored.background": null,
-        "ignored.border": null,
+        "ignored.background": "#393a3450",
+        "ignored.border": "#393a3450",
         "info": "#296aa3",
-        "info.background": null,
-        "info.border": null,
+        "info.background": "#296aa3",
+        "info.border": "#296aa3",
         "modified": "#296aa3",
-        "modified.background": null,
-        "modified.border": null,
+        "modified.background": "#296aa3",
+        "modified.border": "#296aa3",
         "predictive": null,
         "predictive.background": null,
         "predictive.border": null,
@@ -1013,162 +511,234 @@
         "unreachable.background": null,
         "unreachable.border": null,
         "warning": "#a65e2b",
-        "warning.background": null,
-        "warning.border": null,
-        "players": [],
+        "warning.background": "#a65e2b",
+        "warning.border": "#a65e2b",
+        "players": [
+          {
+            "cursor": "#10a793ff",
+            "background": "#10a793ff",
+            "selection": "#10a7933d"
+          },
+          {
+            "cursor": "#c74cecff",
+            "background": "#c74cecff",
+            "selection": "#c74cec3d"
+          },
+          {
+            "cursor": "#f29c14ff",
+            "background": "#f29c14ff",
+            "selection": "#f29c143d"
+          },
+          {
+            "cursor": "#893ea6ff",
+            "background": "#893ea6ff",
+            "selection": "#893ea63d"
+          },
+          {
+            "cursor": "#08e7c5ff",
+            "background": "#08e7c5ff",
+            "selection": "#08e7c53d"
+          },
+          {
+            "cursor": "#f82871ff",
+            "background": "#f82871ff",
+            "selection": "#f828713d"
+          },
+          {
+            "cursor": "#fee56cff",
+            "background": "#fee56cff",
+            "selection": "#fee56c3d"
+          },
+          {
+            "cursor": "#96df71ff",
+            "background": "#96df71ff",
+            "selection": "#96df713d"
+          }
+        ],
         "syntax": {
           "attribute": {
             "color": "#b07d48",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "comment": {
             "color": "#a0ada0",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
             "color": "#a0ada0",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "constant": {
             "color": "#a65e2b",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
             "color": "#393a34",
+            "background_color": null,
             "font_style": "italic",
             "font_weight": null
           },
           "emphasis.strong": {
             "color": "#393a34",
+            "background_color": null,
             "font_style": null,
             "font_weight": 700
           },
           "function": {
             "color": "#59873a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "keyword": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "label": {
             "color": "#59873a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "link_uri": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "number": {
             "color": "#2f798a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "operator": {
             "color": "#ab5959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#999999",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "tag": {
             "color": "#1e754f",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
             "color": "#b56959",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "title": {
             "color": "#59873a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "type": {
             "color": "#2e8f82",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "variable": {
             "color": "#b07d48",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "variable.special": {
             "color": "#a65e2b",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           }
@@ -1176,30 +746,32 @@
       }
     },
     {
-      "name": "Vitesse Black",
+      "name": "Vitesse Dark",
       "appearance": "dark",
       "style": {
+        "background.appearance": "opaque",
+        "accents": [],
         "border": "#191919",
         "border.variant": "#191919",
         "border.focused": "#00000000",
         "border.selected": "#191919",
         "border.transparent": "#191919",
         "border.disabled": "#191919",
-        "elevated_surface.background": "#000",
-        "surface.background": "#000",
-        "background": "#000",
+        "elevated_surface.background": "#121212",
+        "surface.background": "#121212",
+        "background": "#121212",
         "element.background": "#4d9375",
-        "element.hover": "#121212",
+        "element.hover": "#181818",
         "element.active": null,
-        "element.selected": "#121212",
+        "element.selected": "#181818",
         "element.disabled": null,
         "drop_target.background": null,
         "ghost_element.background": null,
-        "ghost_element.hover": "#121212",
+        "ghost_element.hover": "#181818",
         "ghost_element.active": null,
-        "ghost_element.selected": "#121212",
+        "ghost_element.selected": "#181818",
         "ghost_element.disabled": null,
-        "text": "#dbd7cacc",
+        "text": "#dbd7caee",
         "text.muted": "#959da5",
         "text.placeholder": null,
         "text.disabled": null,
@@ -1209,32 +781,36 @@
         "icon.disabled": null,
         "icon.placeholder": null,
         "icon.accent": null,
-        "status_bar.background": "#000",
-        "title_bar.background": "#000",
-        "toolbar.background": "#121212",
-        "tab_bar.background": "#000",
-        "tab.inactive_background": "#000",
-        "tab.active_background": "#000",
+        "status_bar.background": "#121212",
+        "title_bar.background": "#121212",
+        "title_bar.inactive_background": null,
+        "toolbar.background": "#181818",
+        "tab_bar.background": "#121212",
+        "tab.inactive_background": "#121212",
+        "tab.active_background": "#121212",
         "search.match_background": null,
-        "panel.background": "#000",
+        "panel.background": "#121212",
         "panel.focused_border": null,
         "pane.focused_border": null,
+        "pane_group.border": "#191919",
         "scrollbar.thumb.background": "#dedcd510",
         "scrollbar.thumb.hover_background": "#dedcd550",
         "scrollbar.thumb.border": "#dedcd510",
-        "scrollbar.track.background": "#000",
+        "scrollbar.track.background": "#121212",
         "scrollbar.track.border": "#111",
-        "editor.foreground": "#dbd7cacc",
-        "editor.background": "#000",
-        "editor.gutter.background": "#000",
+        "editor.foreground": "#dbd7caee",
+        "editor.background": "#121212",
+        "editor.gutter.background": "#121212",
         "editor.subheader.background": null,
-        "editor.active_line.background": "#121212",
+        "editor.active_line.background": "#181818",
         "editor.highlighted_line.background": null,
         "editor.line_number": "#dedcd550",
-        "editor.active_line_number": "#dbd7cacc",
+        "editor.active_line_number": "#dbd7caee",
         "editor.invisible": null,
         "editor.wrap_guide": "#191919",
         "editor.active_wrap_guide": "#191919",
+        "editor.indent_guide": null,
+        "editor.indent_guide_active": null,
         "editor.document_highlight.read_background": null,
         "editor.document_highlight.write_background": null,
         "terminal.background": null,
@@ -1267,32 +843,32 @@
         "terminal.ansi.dim_white": null,
         "link_text.hover": "#4d9375",
         "conflict": "#d4976c",
-        "conflict.background": null,
-        "conflict.border": null,
+        "conflict.background": "#d4976c",
+        "conflict.border": "#d4976c",
         "created": "#4d9375",
-        "created.background": null,
-        "created.border": null,
+        "created.background": "#4d9375",
+        "created.border": "#4d9375",
         "deleted": "#cb7676",
-        "deleted.background": null,
-        "deleted.border": null,
+        "deleted.background": "#cb7676",
+        "deleted.border": "#cb7676",
         "error": "#cb7676",
-        "error.background": null,
-        "error.border": null,
+        "error.background": "#cb7676",
+        "error.border": "#cb7676",
         "hidden": "#959da5",
-        "hidden.background": null,
-        "hidden.border": null,
-        "hint": "#444444",
-        "hint.background": null,
-        "hint.border": null,
+        "hidden.background": "#959da5",
+        "hidden.border": "#959da5",
+        "hint": "#666666",
+        "hint.background": "#666666",
+        "hint.border": "#666666",
         "ignored": "#dedcd550",
-        "ignored.background": null,
-        "ignored.border": null,
+        "ignored.background": "#dedcd550",
+        "ignored.border": "#dedcd550",
         "info": "#6394bf",
-        "info.background": null,
-        "info.border": null,
+        "info.background": "#6394bf",
+        "info.border": "#6394bf",
         "modified": "#6394bf",
-        "modified.background": null,
-        "modified.border": null,
+        "modified.background": "#6394bf",
+        "modified.border": "#6394bf",
         "predictive": null,
         "predictive.background": null,
         "predictive.border": null,
@@ -1306,162 +882,976 @@
         "unreachable.background": null,
         "unreachable.border": null,
         "warning": "#d4976c",
-        "warning.background": null,
-        "warning.border": null,
-        "players": [],
+        "warning.background": "#d4976c",
+        "warning.border": "#d4976c",
+        "players": [
+          {
+            "cursor": "#10a793ff",
+            "background": "#10a793ff",
+            "selection": "#10a7933d"
+          },
+          {
+            "cursor": "#c74cecff",
+            "background": "#c74cecff",
+            "selection": "#c74cec3d"
+          },
+          {
+            "cursor": "#f29c14ff",
+            "background": "#f29c14ff",
+            "selection": "#f29c143d"
+          },
+          {
+            "cursor": "#893ea6ff",
+            "background": "#893ea6ff",
+            "selection": "#893ea63d"
+          },
+          {
+            "cursor": "#08e7c5ff",
+            "background": "#08e7c5ff",
+            "selection": "#08e7c53d"
+          },
+          {
+            "cursor": "#f82871ff",
+            "background": "#f82871ff",
+            "selection": "#f828713d"
+          },
+          {
+            "cursor": "#fee56cff",
+            "background": "#fee56cff",
+            "selection": "#fee56c3d"
+          },
+          {
+            "cursor": "#96df71ff",
+            "background": "#96df71ff",
+            "selection": "#96df713d"
+          }
+        ],
         "syntax": {
           "attribute": {
             "color": "#bd976a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "boolean": {
             "color": "#4d9375",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "comment": {
             "color": "#758575dd",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
             "color": "#758575dd",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "constant": {
             "color": "#c99076",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "constructor": {
             "color": "#4d9375",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "emphasis": {
-            "color": "#dbd7cacc",
+            "color": "#dbd7caee",
+            "background_color": null,
             "font_style": "italic",
             "font_weight": null
           },
           "emphasis.strong": {
-            "color": "#dbd7cacc",
+            "color": "#dbd7caee",
+            "background_color": null,
             "font_style": null,
             "font_weight": 700
           },
           "function": {
             "color": "#80a665",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "keyword": {
             "color": "#4d9375",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "label": {
             "color": "#80a665",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "link_text": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "link_uri": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "number": {
             "color": "#4C9A91",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "operator": {
             "color": "#cb7676",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation": {
-            "color": "#444444",
+            "color": "#666666",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "#444444",
+            "color": "#666666",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.delimiter": {
-            "color": "#444444",
+            "color": "#666666",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.list_marker": {
-            "color": "#444444",
+            "color": "#666666",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
-            "color": "#444444",
+            "color": "#666666",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.escape": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.special": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "string.special.symbol": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "tag": {
             "color": "#4d9375",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "text.literal": {
             "color": "#c98a7d",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "title": {
             "color": "#80a665",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "type": {
             "color": "#5DA994",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "variable": {
             "color": "#bd976a",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           },
           "variable.special": {
             "color": "#c99076",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Vitesse Dark Soft",
+      "appearance": "dark",
+      "style": {
+        "background.appearance": "opaque",
+        "accents": [],
+        "border": "#252525",
+        "border.variant": "#252525",
+        "border.focused": "#00000000",
+        "border.selected": "#252525",
+        "border.transparent": "#252525",
+        "border.disabled": "#252525",
+        "elevated_surface.background": "#222",
+        "surface.background": "#222",
+        "background": "#222",
+        "element.background": "#4d9375",
+        "element.hover": "#292929",
+        "element.active": null,
+        "element.selected": "#292929",
+        "element.disabled": null,
+        "drop_target.background": null,
+        "ghost_element.background": null,
+        "ghost_element.hover": "#292929",
+        "ghost_element.active": null,
+        "ghost_element.selected": "#292929",
+        "ghost_element.disabled": null,
+        "text": "#dbd7caee",
+        "text.muted": "#959da5",
+        "text.placeholder": null,
+        "text.disabled": null,
+        "text.accent": null,
+        "icon": null,
+        "icon.muted": null,
+        "icon.disabled": null,
+        "icon.placeholder": null,
+        "icon.accent": null,
+        "status_bar.background": "#222",
+        "title_bar.background": "#222",
+        "title_bar.inactive_background": null,
+        "toolbar.background": "#292929",
+        "tab_bar.background": "#222",
+        "tab.inactive_background": "#222",
+        "tab.active_background": "#222",
+        "search.match_background": null,
+        "panel.background": "#222",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "pane_group.border": "#252525",
+        "scrollbar.thumb.background": "#dedcd510",
+        "scrollbar.thumb.hover_background": "#dedcd550",
+        "scrollbar.thumb.border": "#dedcd510",
+        "scrollbar.track.background": "#222",
+        "scrollbar.track.border": "#111",
+        "editor.foreground": "#dbd7caee",
+        "editor.background": "#222",
+        "editor.gutter.background": "#222",
+        "editor.subheader.background": null,
+        "editor.active_line.background": "#292929",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#dedcd550",
+        "editor.active_line_number": "#dbd7caee",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#252525",
+        "editor.active_wrap_guide": "#252525",
+        "editor.indent_guide": null,
+        "editor.indent_guide_active": null,
+        "editor.document_highlight.read_background": null,
+        "editor.document_highlight.write_background": null,
+        "terminal.background": null,
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#393a34",
+        "terminal.ansi.bright_black": "#777777",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#cb7676",
+        "terminal.ansi.bright_red": "#cb7676",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#4d9375",
+        "terminal.ansi.bright_green": "#4d9375",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#e6cc77",
+        "terminal.ansi.bright_yellow": "#e6cc77",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#6394bf",
+        "terminal.ansi.bright_blue": "#6394bf",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#d9739f",
+        "terminal.ansi.bright_magenta": "#d9739f",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#5eaab5",
+        "terminal.ansi.bright_cyan": "#5eaab5",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#dbd7ca",
+        "terminal.ansi.bright_white": "#ffffff",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#4d9375",
+        "conflict": "#d4976c",
+        "conflict.background": "#d4976c",
+        "conflict.border": "#d4976c",
+        "created": "#4d9375",
+        "created.background": "#4d9375",
+        "created.border": "#4d9375",
+        "deleted": "#cb7676",
+        "deleted.background": "#cb7676",
+        "deleted.border": "#cb7676",
+        "error": "#cb7676",
+        "error.background": "#cb7676",
+        "error.border": "#cb7676",
+        "hidden": "#959da5",
+        "hidden.background": "#959da5",
+        "hidden.border": "#959da5",
+        "hint": "#666666",
+        "hint.background": "#666666",
+        "hint.border": "#666666",
+        "ignored": "#dedcd550",
+        "ignored.background": "#dedcd550",
+        "ignored.border": "#dedcd550",
+        "info": "#6394bf",
+        "info.background": "#6394bf",
+        "info.border": "#6394bf",
+        "modified": "#6394bf",
+        "modified.background": "#6394bf",
+        "modified.border": "#6394bf",
+        "predictive": null,
+        "predictive.background": null,
+        "predictive.border": null,
+        "renamed": null,
+        "renamed.background": null,
+        "renamed.border": null,
+        "success": null,
+        "success.background": null,
+        "success.border": null,
+        "unreachable": null,
+        "unreachable.background": null,
+        "unreachable.border": null,
+        "warning": "#d4976c",
+        "warning.background": "#d4976c",
+        "warning.border": "#d4976c",
+        "players": [
+          {
+            "cursor": "#10a793ff",
+            "background": "#10a793ff",
+            "selection": "#10a7933d"
+          },
+          {
+            "cursor": "#c74cecff",
+            "background": "#c74cecff",
+            "selection": "#c74cec3d"
+          },
+          {
+            "cursor": "#f29c14ff",
+            "background": "#f29c14ff",
+            "selection": "#f29c143d"
+          },
+          {
+            "cursor": "#893ea6ff",
+            "background": "#893ea6ff",
+            "selection": "#893ea63d"
+          },
+          {
+            "cursor": "#08e7c5ff",
+            "background": "#08e7c5ff",
+            "selection": "#08e7c53d"
+          },
+          {
+            "cursor": "#f82871ff",
+            "background": "#f82871ff",
+            "selection": "#f828713d"
+          },
+          {
+            "cursor": "#fee56cff",
+            "background": "#fee56cff",
+            "selection": "#fee56c3d"
+          },
+          {
+            "cursor": "#96df71ff",
+            "background": "#96df71ff",
+            "selection": "#96df713d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#bd976a",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#758575dd",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#758575dd",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#c99076",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#dbd7caee",
+            "background_color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#dbd7caee",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#80a665",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#80a665",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#4C9A91",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#cb7676",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#666666",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#666666",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#666666",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#666666",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#666666",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#80a665",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#5DA994",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#bd976a",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#c99076",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Vitesse Black",
+      "appearance": "dark",
+      "style": {
+        "background.appearance": "opaque",
+        "accents": [],
+        "border": "#191919",
+        "border.variant": "#191919",
+        "border.focused": "#00000000",
+        "border.selected": "#191919",
+        "border.transparent": "#191919",
+        "border.disabled": "#191919",
+        "elevated_surface.background": "#000",
+        "surface.background": "#000",
+        "background": "#000",
+        "element.background": "#4d9375",
+        "element.hover": "#121212",
+        "element.active": null,
+        "element.selected": "#121212",
+        "element.disabled": null,
+        "drop_target.background": null,
+        "ghost_element.background": null,
+        "ghost_element.hover": "#121212",
+        "ghost_element.active": null,
+        "ghost_element.selected": "#121212",
+        "ghost_element.disabled": null,
+        "text": "#dbd7cacc",
+        "text.muted": "#959da5",
+        "text.placeholder": null,
+        "text.disabled": null,
+        "text.accent": null,
+        "icon": null,
+        "icon.muted": null,
+        "icon.disabled": null,
+        "icon.placeholder": null,
+        "icon.accent": null,
+        "status_bar.background": "#000",
+        "title_bar.background": "#000",
+        "title_bar.inactive_background": null,
+        "toolbar.background": "#121212",
+        "tab_bar.background": "#000",
+        "tab.inactive_background": "#000",
+        "tab.active_background": "#000",
+        "search.match_background": null,
+        "panel.background": "#000",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "pane_group.border": "#191919",
+        "scrollbar.thumb.background": "#dedcd510",
+        "scrollbar.thumb.hover_background": "#dedcd550",
+        "scrollbar.thumb.border": "#dedcd510",
+        "scrollbar.track.background": "#000",
+        "scrollbar.track.border": "#111",
+        "editor.foreground": "#dbd7cacc",
+        "editor.background": "#000",
+        "editor.gutter.background": "#000",
+        "editor.subheader.background": null,
+        "editor.active_line.background": "#121212",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#dedcd550",
+        "editor.active_line_number": "#dbd7cacc",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#191919",
+        "editor.active_wrap_guide": "#191919",
+        "editor.indent_guide": null,
+        "editor.indent_guide_active": null,
+        "editor.document_highlight.read_background": null,
+        "editor.document_highlight.write_background": null,
+        "terminal.background": null,
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#393a34",
+        "terminal.ansi.bright_black": "#777777",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#cb7676",
+        "terminal.ansi.bright_red": "#cb7676",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#4d9375",
+        "terminal.ansi.bright_green": "#4d9375",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#e6cc77",
+        "terminal.ansi.bright_yellow": "#e6cc77",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#6394bf",
+        "terminal.ansi.bright_blue": "#6394bf",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#d9739f",
+        "terminal.ansi.bright_magenta": "#d9739f",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#5eaab5",
+        "terminal.ansi.bright_cyan": "#5eaab5",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#dbd7ca",
+        "terminal.ansi.bright_white": "#ffffff",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#4d9375",
+        "conflict": "#d4976c",
+        "conflict.background": "#d4976c",
+        "conflict.border": "#d4976c",
+        "created": "#4d9375",
+        "created.background": "#4d9375",
+        "created.border": "#4d9375",
+        "deleted": "#cb7676",
+        "deleted.background": "#cb7676",
+        "deleted.border": "#cb7676",
+        "error": "#cb7676",
+        "error.background": "#cb7676",
+        "error.border": "#cb7676",
+        "hidden": "#959da5",
+        "hidden.background": "#959da5",
+        "hidden.border": "#959da5",
+        "hint": "#444444",
+        "hint.background": "#444444",
+        "hint.border": "#444444",
+        "ignored": "#dedcd550",
+        "ignored.background": "#dedcd550",
+        "ignored.border": "#dedcd550",
+        "info": "#6394bf",
+        "info.background": "#6394bf",
+        "info.border": "#6394bf",
+        "modified": "#6394bf",
+        "modified.background": "#6394bf",
+        "modified.border": "#6394bf",
+        "predictive": null,
+        "predictive.background": null,
+        "predictive.border": null,
+        "renamed": null,
+        "renamed.background": null,
+        "renamed.border": null,
+        "success": null,
+        "success.background": null,
+        "success.border": null,
+        "unreachable": null,
+        "unreachable.background": null,
+        "unreachable.border": null,
+        "warning": "#d4976c",
+        "warning.background": "#d4976c",
+        "warning.border": "#d4976c",
+        "players": [
+          {
+            "cursor": "#10a793ff",
+            "background": "#10a793ff",
+            "selection": "#10a7933d"
+          },
+          {
+            "cursor": "#c74cecff",
+            "background": "#c74cecff",
+            "selection": "#c74cec3d"
+          },
+          {
+            "cursor": "#f29c14ff",
+            "background": "#f29c14ff",
+            "selection": "#f29c143d"
+          },
+          {
+            "cursor": "#893ea6ff",
+            "background": "#893ea6ff",
+            "selection": "#893ea63d"
+          },
+          {
+            "cursor": "#08e7c5ff",
+            "background": "#08e7c5ff",
+            "selection": "#08e7c53d"
+          },
+          {
+            "cursor": "#f82871ff",
+            "background": "#f82871ff",
+            "selection": "#f828713d"
+          },
+          {
+            "cursor": "#fee56cff",
+            "background": "#fee56cff",
+            "selection": "#fee56c3d"
+          },
+          {
+            "cursor": "#96df71ff",
+            "background": "#96df71ff",
+            "selection": "#96df713d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#bd976a",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#758575dd",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#758575dd",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#c99076",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#dbd7cacc",
+            "background_color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#dbd7cacc",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#80a665",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#80a665",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#4C9A91",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#cb7676",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#444444",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#444444",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#444444",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#444444",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#444444",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#4d9375",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#c98a7d",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#80a665",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#5DA994",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#bd976a",
+            "background_color": null,
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#c99076",
+            "background_color": null,
             "font_style": null,
             "font_weight": null
           }


### PR DESCRIPTION
# Before

The default theme_importer conversion has some flaws, such as warning hints, they are unreadable.

<img width="619" alt="image" src="https://github.com/user-attachments/assets/447e08dd-afe6-4591-81f7-d8595667624a">

As well as selections

<img width="594" alt="image" src="https://github.com/user-attachments/assets/8eb09ff9-f288-45c1-b6a8-fcbe28196540">

# After
<img width="578" alt="image" src="https://github.com/user-attachments/assets/3abd27e6-e6b3-4b21-a52f-c80876f00a97">

<img width="586" alt="image" src="https://github.com/user-attachments/assets/f6a3cb92-9e9a-4009-ada9-ec50b0f219a5">


